### PR TITLE
Add input file name to Token objects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,31 @@
+BasedOnStyle: LLVM
+
+TabWidth: 2
+ColumnLimit: 100
+UseTab: Never
+
+CommentPragmas: '^/'
+ReflowComments: true
+AlignTrailingComments: true
+SpacesBeforeTrailingComments: 1
+
+SpaceBeforeParens: ControlStatements
+SpacesInSquareBrackets: false
+BreakBeforeBraces: Allman
+PointerAlignment: Middle
+
+BinPackParameters: false
+BinPackArguments: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+SortIncludes: false
+IndentCaseLabels: true
+ConstructorInitializerIndentWidth: 2
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakTemplateDeclarations: true
+
+FixNamespaceComments: false

--- a/contrib/hit/lex.cc
+++ b/contrib/hit/lex.cc
@@ -70,11 +70,7 @@ tokTypeName(TokType t)
   // clang-format on
 }
 
-Token::Token(TokType t,
-             const std::string & val,
-             const std::shared_ptr<std::string> & name,
-             size_t offset,
-             int line)
+Token::Token(TokType t, const std::string & val, const std::string & name, size_t offset, int line)
   : type(t), val(val), name(name), offset(offset), line(line)
 {
 }
@@ -87,10 +83,7 @@ Token::str()
   return tokTypeName(type) + ":'" + val + "'";
 }
 
-Lexer::Lexer(const std::string & name, const std::string & input)
-  : _name(std::make_shared<std::string>(name)), _input(input)
-{
-}
+Lexer::Lexer(const std::string & name, const std::string & input) : _name(name), _input(input) {}
 
 std::vector<Token> &
 Lexer::tokens()

--- a/contrib/hit/lex.h
+++ b/contrib/hit/lex.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace hit
 {
@@ -32,7 +33,11 @@ enum class TokType
 /// Token represents an (atomic) token/quantum of input text.
 struct Token
 {
-  Token(TokType t, const std::string & val, size_t offset = 0, int line = 0);
+  Token(TokType t,
+        const std::string & val,
+        const std::shared_ptr<std::string> & name,
+        size_t offset = 0,
+        int line = 0);
   /// str returns a human-friendly string representation of the token.
   std::string str();
 
@@ -40,6 +45,8 @@ struct Token
   TokType type;
   /// val is the actual text from the input that makes this token.
   std::string val;
+  /// name of the original input file
+  std::shared_ptr<std::string> name;
   /// offset is the byte offset into the original input identifying the start position where this
   /// token was found.  This can be used to determine line numbers, column offsets, etc. useful for
   /// error messages among other things.
@@ -146,7 +153,7 @@ public:
 
 private:
   int _line_count = 1;
-  std::string _name;
+  std::shared_ptr<std::string> _name;
   std::string _input;
   size_t _start = 0;
   size_t _pos = 0;

--- a/contrib/hit/lex.h
+++ b/contrib/hit/lex.h
@@ -35,7 +35,7 @@ struct Token
 {
   Token(TokType t,
         const std::string & val,
-        const std::shared_ptr<std::string> & name,
+        const std::string & name,
         size_t offset = 0,
         int line = 0);
   /// str returns a human-friendly string representation of the token.
@@ -46,7 +46,7 @@ struct Token
   /// val is the actual text from the input that makes this token.
   std::string val;
   /// name of the original input file
-  std::shared_ptr<std::string> name;
+  std::string name;
   /// offset is the byte offset into the original input identifying the start position where this
   /// token was found.  This can be used to determine line numbers, column offsets, etc. useful for
   /// error messages among other things.
@@ -153,7 +153,7 @@ public:
 
 private:
   int _line_count = 1;
-  std::shared_ptr<std::string> _name;
+  std::string _name;
   std::string _input;
   size_t _start = 0;
   size_t _pos = 0;

--- a/contrib/hit/parse.cc
+++ b/contrib/hit/parse.cc
@@ -1,12 +1,12 @@
 
-#include <string>
-#include <vector>
 #include <algorithm>
-#include <sstream>
-#include <set>
 #include <iterator>
 #include <memory>
 #include <regex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "parse.h"
 
@@ -186,6 +186,14 @@ void
 Node::remove()
 {
   delete this;
+}
+
+std::string
+Node::name()
+{
+  if (_toks.size() > 0)
+    return *_toks[0].name;
+  return "";
 }
 
 int
@@ -690,7 +698,7 @@ public:
     if (_pos >= _tokens.size())
     {
       _pos++;
-      return Token{TokType::EOF, "", _input.size()};
+      return Token{TokType::EOF, "", std::make_shared<std::string>(_name), _input.size()};
     }
     auto tok = _tokens[_pos];
     _pos++;

--- a/contrib/hit/parse.cc
+++ b/contrib/hit/parse.cc
@@ -188,12 +188,13 @@ Node::remove()
   delete this;
 }
 
-std::string
+const std::string &
 Node::name()
 {
   if (_toks.size() > 0)
-    return *_toks[0].name;
-  return "";
+    return _toks[0].name;
+  static std::string unknown_name = "[unknown]";
+  return unknown_name;
 }
 
 int
@@ -698,7 +699,7 @@ public:
     if (_pos >= _tokens.size())
     {
       _pos++;
-      return Token{TokType::EOF, "", std::make_shared<std::string>(_name), _input.size()};
+      return Token{TokType::EOF, "", _name, _input.size()};
     }
     auto tok = _tokens[_pos];
     _pos++;

--- a/contrib/hit/parse.h
+++ b/contrib/hit/parse.h
@@ -1,13 +1,13 @@
 #ifndef HIT_PARSE
 #define HIT_PARSE
 
-#include <string>
-#include <vector>
-#include <map>
 #include <algorithm>
-#include <typeinfo>
 #include <cstdint>
 #include <iostream>
+#include <map>
+#include <string>
+#include <typeinfo>
+#include <vector>
 
 #include "lex.h"
 
@@ -147,6 +147,9 @@ public:
   /// line returns the line number of the original parsed input (file) that contained the start of
   /// the content that this node was built from.
   int line();
+  /// name returns the file name of the original parsed input (file) that contained the start of
+  /// the content that this node was built from.
+  std::string name();
 
   /// the following functions return the stored value of the node (if any exists) of the type
   /// indicated in the function name. If the node holds a value of a different type or doesn't hold
@@ -267,7 +270,7 @@ inline unsigned int
 Node::paramInner(Node * n)
 {
   if (n->intVal() < 0)
-    throw Error("negative value read from an input file on line " +
+    throw Error("negative value read from file '" + n->name() + "' on line " +
                 std::to_string(n->line()));
   return n->intVal();
 }
@@ -301,9 +304,10 @@ Node::paramInner(Node * n)
 {
   auto tmp = n->vecIntVal();
   std::vector<unsigned int> vec;
-  for (auto val : tmp) {
+  for (auto val : tmp)
+  {
     if (val < 0)
-      throw Error("negative value read from an input file on line " +
+      throw Error("negative value read from file '" + n->name() + "' on line " +
                   std::to_string(n->line()));
     vec.push_back(val);
   }

--- a/contrib/hit/parse.h
+++ b/contrib/hit/parse.h
@@ -149,7 +149,7 @@ public:
   int line();
   /// name returns the file name of the original parsed input (file) that contained the start of
   /// the content that this node was built from.
-  std::string name();
+  const std::string & name();
 
   /// the following functions return the stored value of the node (if any exists) of the type
   /// indicated in the function name. If the node holds a value of a different type or doesn't hold

--- a/contrib/unit/src/HitTests.C
+++ b/contrib/unit/src/HitTests.C
@@ -627,26 +627,32 @@ TEST(HitTests, Formatter_sorting)
   }
 }
 
-TEST(HitTests, unsigned_int) {
-  hit::Node *root = nullptr;
-  try {
+TEST(HitTests, unsigned_int)
+{
+  hit::Node * root = nullptr;
+  try
+  {
     root = hit::parse("TESTCASE", "par = -3");
     root->param<unsigned int>("par");
     FAIL() << "Exception was not thrown";
-  } catch (std::exception &err) {
-    EXPECT_EQ("negative value read from an input file on line 1",
-              std::string(err.what()));
+  }
+  catch (std::exception & err)
+  {
+    EXPECT_EQ("negative value read from file 'TESTCASE' on line 1", std::string(err.what()));
   }
 }
 
-TEST(HitTests, vector_unsigned_int) {
-  hit::Node *root = nullptr;
-  try {
+TEST(HitTests, vector_unsigned_int)
+{
+  hit::Node * root = nullptr;
+  try
+  {
     root = hit::parse("TESTCASE", "par = '-3 0 1'");
     root->param<std::vector<unsigned int>>("par");
     FAIL() << "Exception was not thrown";
-  } catch (std::exception &err) {
-    EXPECT_EQ("negative value read from an input file on line 1",
-              std::string(err.what()));
+  }
+  catch (std::exception & err)
+  {
+    EXPECT_EQ("negative value read from file 'TESTCASE' on line 1", std::string(err.what()));
   }
 }


### PR DESCRIPTION
This will make it possible to supply the original input file name for the location of any Node in a HIT tree, even (or especially) after merging HIT trees from multiple input files.

Closes #68