### PR TITLE
Walker specific defaults

### DIFF
--- a/contrib/hit/main.cc
+++ b/contrib/hit/main.cc
@@ -586,12 +586,12 @@ common(int argc, char ** argv)
 
   hit::GatherParamWalker::ParamMap common_params;
   hit::GatherParamWalker common_walker(common_params);
-  roots[0]->walk(&common_walker, hit::NodeType::Field);
+  roots[0]->walk(&common_walker);
   for (std::size_t i = 1; i < roots.size(); ++i)
   {
     hit::GatherParamWalker::ParamMap next_params;
     hit::GatherParamWalker next_walker(next_params);
-    roots[i]->walk(&next_walker, hit::NodeType::Field);
+    roots[i]->walk(&next_walker);
 
     for (auto it1 = common_params.begin(); it1 != common_params.end();)
     {
@@ -640,9 +640,9 @@ subtract(int argc, char ** argv)
   hit::RemoveParamWalker right_walker(left_params);
   hit::RemoveEmptySectionWalker right_section_walker;
 
-  left->walk(&left_walker, hit::NodeType::Field);
-  right->walk(&right_walker, hit::NodeType::Section);
-  right->walk(&right_section_walker, hit::NodeType::Section, /* children_first = */ true);
+  left->walk(&left_walker);
+  right->walk(&right_walker);
+  right->walk(&right_section_walker);
 
   std::cout << right->render();
 

--- a/contrib/hit/parse.cc
+++ b/contrib/hit/parse.cc
@@ -321,18 +321,21 @@ Node::fullpath()
 }
 
 void
-Node::walk(Walker * w, NodeType t, bool children_first)
+Node::walk(Walker * w, NodeType t, TraversalOrder o)
 {
-  if (children_first)
+  // traverse children first
+  if (o == TraversalOrder::AfterChildren)
     for (auto child : _children)
-      child->walk(w, t, children_first);
+      child->walk(w, t, o);
 
+  // execute walker
   if (_type == t || t == NodeType::All)
     w->walk(fullpath(), pathNorm(path()), this);
 
-  if (!children_first)
+  // traverse children last
+  if (o == TraversalOrder::BeforeChildren)
     for (auto child : _children)
-      child->walk(w, t, children_first);
+      child->walk(w, t, o);
 }
 
 Node *
@@ -982,6 +985,8 @@ public:
     }
   }
 
+  NodeType nodeType() override { return NodeType::Section; }
+
 private:
   std::set<std::string> _done;
   Node * _orig;
@@ -992,8 +997,8 @@ merge(Node * from, Node * into)
 {
   MergeFieldWalker fw(into);
   MergeSectionWalker sw(into);
-  from->walk(&fw, NodeType::Field);
-  from->walk(&sw, NodeType::Section);
+  from->walk(&fw);
+  from->walk(&sw);
 }
 
 Node *

--- a/contrib/unit/src/HitTests.C
+++ b/contrib/unit/src/HitTests.C
@@ -561,7 +561,7 @@ TEST(HitTests, GatherParamWalker)
     auto root = hit::parse("TESTCASE", test.first);
     hit::GatherParamWalker::ParamMap params;
     hit::GatherParamWalker walker(params);
-    root->walk(&walker, hit::NodeType::Field);
+    root->walk(&walker);
 
     if (test.second.size() != params.size())
       FAIL() << "case " << test.first << " failed.";
@@ -591,8 +591,8 @@ TEST(HitTests, RemoveParamWalker)
     hit::GatherParamWalker gather_walker(params);
     hit::RemoveParamWalker remove_walker(params);
 
-    root2->walk(&gather_walker, hit::NodeType::Field);
-    root1->walk(&remove_walker, hit::NodeType::Section);
+    root2->walk(&gather_walker);
+    root1->walk(&remove_walker);
 
     EXPECT_EQ(root1->render(), test[2]);
   }
@@ -611,7 +611,7 @@ TEST(HitTests, RemoveEmptySectionWalker)
     auto root = hit::parse("TESTCASE", test[0]);
 
     hit::RemoveEmptySectionWalker walker;
-    root->walk(&walker, hit::NodeType::Section, true);
+    root->walk(&walker);
 
     EXPECT_EQ(root->render(), test[1]);
   }


### PR DESCRIPTION
As mentioned in #95, having Walker specific defaults for applicable node type and execution order (before or after child nodes are traversed) would make the Walker interface a bit friendlier. I accidentally ran my walkers with the wrong node type and execution order a bunch of times, leading to unexpected results (and wasted time for debugging).

Refs #95